### PR TITLE
Appending an int to a string does not append to the string

### DIFF
--- a/src/TypedOption.cpp
+++ b/src/TypedOption.cpp
@@ -118,7 +118,7 @@ namespace ahoy {
 			defaultString += to_string(value);
 		}
 		defaultString += "]";
-		return Option::help() + " [vec<int>" + (countValue < 0 ? "" : ", " + countValue) + "]" + (hasDefault ? (" [default: " + defaultString + "]") : "");
+		return Option::help() + " [vec<int>" + (countValue < 0 ? "" : ", " + to_string(countValue)) + "]" + (hasDefault ? (" [default: " + defaultString + "]") : "");
 	}
 
 	template<>


### PR DESCRIPTION
Clang points out that appending an int to a string does not append to the string.