### PR TITLE
Classes with virtual methods should have virtual destructors.

### DIFF
--- a/include/ahoy/Option.h
+++ b/include/ahoy/Option.h
@@ -25,5 +25,7 @@ namespace ahoy {
 		virtual std::string help() {
 			return helpPrefix() + "\t" + helpSuffix();
 		};
+		
+		virtual ~Option() {}
 	};
 }


### PR DESCRIPTION
Clang warns that you call a deleter on Option, which has virtual methods but no virtual destructor.